### PR TITLE
Implement deferred loading of packages

### DIFF
--- a/Install/toolbox/btm.pyt
+++ b/Install/toolbox/btm.pyt
@@ -1051,6 +1051,22 @@ class depthstatistics(object):
         return
 
     def updateMessages(self, parameters):
+        stats = []
+        if parameters[3].value:
+            stats = parameters[3].valueAsText.split(";")
+
+        if not utils.NETCDF4_EXISTS and ('Kurtosis' in stats or \
+                'Interquartile Range' in stats):
+            parameters[3].setWarningMessage(
+                    "The interquartile range and kurtosis tools require "
+                    "the NetCDF4 Python library is installed. NetCDF4 "
+                    "is included in ArcGIS 10.3 and later.")
+
+        if not utils.SCIPY_EXISTS and 'Kurtosis' in stats:
+            parameters[3].setWarningMessage(
+                "The kurtosis calculation requires the SciPy library "
+                "is installed. SciPy is included in ArcGIS 10.4 and "
+                "later versions.")
         return
 
     def execute(self, parameters, messages):
@@ -1140,6 +1156,11 @@ class scalecomparison(object):
         return
 
     def updateMessages(self, parameters):
+        if not utils.SCIPY_EXISTS:
+            parameters[0].setWarningMessage(
+                "This tool requires the SciPy module is "
+                "installed. SciPy is included in ArcGIS 10.4 "
+                "and later versions.")
         return
 
     def execute(self, parameters, messages):
@@ -1207,6 +1228,22 @@ class multiplescales(object):
         return
 
     def updateMessages(self, parameters):
+        stats = []
+        if parameters[2].value:
+            stats = parameters[2].valueAsText.split(";")
+
+        if not utils.NETCDF4_EXISTS and ('Kurtosis' in stats or \
+                'Interquartile Range' in stats):
+            parameters[2].setWarningMessage(
+                    "The interquartile range and kurtosis tools require "
+                    "the NetCDF4 Python library is installed. NetCDF4 "
+                    "is included in ArcGIS 10.3 and later.")
+
+        if not utils.SCIPY_EXISTS and 'Kurtosis' in stats:
+            parameters[2].setWarningMessage(
+                "The kurtosis calculation requires the SciPy library "
+                "is installed. SciPy is included in ArcGIS 10.4 and "
+                "later versions.")
         return
 
     def execute(self, parameters, messages):

--- a/Install/toolbox/scripts/depth_statistics.py
+++ b/Install/toolbox/scripts/depth_statistics.py
@@ -8,8 +8,11 @@ import os
 import sys
 import math
 import numpy as np
-import scipy
-from scipy import stats
+try:
+    import scipy
+    from scipy import stats
+except ImportError:
+    pass    # error generated inline
 import arcpy
 from arcpy.sa import NbrRectangle, FocalStatistics, Power
 
@@ -68,6 +71,19 @@ def main(in_raster=None, neighborhood_size=None,
         utils.msg("The following stats will be computed: " +
                   "{}".format(";".join(out_stats)))
 
+    # these two tools both use block processing which requires NetCDF4
+    if 'Interquartile Range' in out_stats or 'Kurtosis' in out_stats:
+        if not utils.NETCDF4_EXISTS:
+            utils.msg("The interquartile range and kurtosis tools require "
+                      "the NetCDF4 Python library is installed. NetCDF4 "
+                      "is included in ArcGIS 10.3 and later.", "error")
+            return
+
+        if 'Kurtosis' in out_stats and not utils.SCIPY_EXISTS:
+            utils.msg("This tool requires the SciPy library is installed.",
+                      "SciPy is included in ArcGIS 10.4 and later versions.",
+                      "error")
+            return
     try:
         # initialize our neighborhood
         if verbose:

--- a/Install/toolbox/scripts/depth_statistics.py
+++ b/Install/toolbox/scripts/depth_statistics.py
@@ -80,9 +80,9 @@ def main(in_raster=None, neighborhood_size=None,
             return
 
         if 'Kurtosis' in out_stats and not utils.SCIPY_EXISTS:
-            utils.msg("This tool requires the SciPy library is installed.",
-                      "SciPy is included in ArcGIS 10.4 and later versions.",
-                      "error")
+            utils.msg("The kurtosis calculation requires the SciPy library "
+                      "is installed. SciPy is included in ArcGIS 10.4 and "
+                      "later versions.", "error")
             return
     try:
         # initialize our neighborhood

--- a/Install/toolbox/scripts/scale_comparison.py
+++ b/Install/toolbox/scripts/scale_comparison.py
@@ -1,13 +1,17 @@
 import arcpy
-from arcpy import Raster
 import numpy as np
-import scipy.ndimage as nd
+import sys
+import scripts.config as config
 import scripts.utils as utils
 from matplotlib import pyplot as plt
 
-import math
-
-import scripts.utils as utils
+if not utils.SCIPY_EXISTS:
+    utils.msg("This tool requires the SciPy module to be " +
+              "installed. SciPy is included in ArcGIS 10.4 " +
+              "and later versions.", "error")
+    sys.exit()
+else:
+    import scipy.ndimage as nd
 
 
 def main(in_raster=None, img_filter=None, percentile=None,

--- a/Install/toolbox/scripts/utils.py
+++ b/Install/toolbox/scripts/utils.py
@@ -13,7 +13,16 @@ import csv
 import math
 import random
 from xml.dom.minidom import parse
-from netCDF4 import Dataset
+try:
+    from netCDF4 import Dataset
+    NETCDF4_EXISTS = True
+except ImportError:
+    NETCDF4_EXISTS = False
+try:
+    import scipy
+    SCIPY_EXISTS = True
+except ImportError:
+    SCIPY_EXISTS = False
 
 import arcpy
 from arcpy import Raster
@@ -192,6 +201,9 @@ class BlockProcessor:
         arcpy.env.overwriteOutput = True
 
     def computeBlockStatistics(self, func, blockSize, outRast, overlap=0):
+        # immediately fail if we don't have a netCDF4 backend available:
+        if not NETCDF4_EXISTS:
+            return None
 
         total_blocks = int(math.ceil(float(self.width) / blockSize) *
                            math.ceil(float(self.height) / blockSize))


### PR DESCRIPTION
For older installations, these packages may not exist. Instead of
assuming their presence, gracefully degrade BTM to disable the
specific functionality using SciPy and NetCDF4. Do this by checking
for the packages, in case the user has installed the libraries
manually. Fixes #115.